### PR TITLE
feat: Latest EVS release checker

### DIFF
--- a/core/src/main/java/org/imec/ivlab/core/version/RemoteVersionReader.java
+++ b/core/src/main/java/org/imec/ivlab/core/version/RemoteVersionReader.java
@@ -11,112 +11,66 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 //import org.apache.logging.log4j.LogManager;
 //import org.apache.logging.log4j.Logger;
-import org.imec.ivlab.core.constants.CoreConstants;
 import org.imec.ivlab.core.exceptions.ExternalConnectionException;
 import org.imec.ivlab.core.exceptions.RemoteVersionCheckFailedException;
 
 import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class RemoteVersionReader {
 
     //private final static Logger LOG = LogManager.getLogger(RemoteVersionReader.class);
 
-    private final static String EVS_VERSION_WIKI_PAGE_ID = "5407680";
-    private final static String CONFLUENCE_CONTENT_API_PATH = "/rest/api/content/";
-    private final static String CONFLUENCE_CONTENT_API_QUERY_PARAMS = "?expand=body.storage";
+    private final static String GITHUB_API_BASE_URL = "https://api.github.com/repos/";
+    private final static String OWNER = "smals-jy"; // Replace with your GitHub username or organization name
+    private final static String REPO_NAME = "evs"; // Replace with your repository name
+    private final static String LATEST_RELEASE_PATH = "/releases/latest";
     private final static int CONNECTION_TIMEOUT = 2000;
     private final static int SOCKET_TIMEOUT = 2000;
 
     protected static String getRemoteVersion() throws RemoteVersionCheckFailedException {
+        GitHubRelease latesGitHubRelease = getLatestGitHubRelease();
+        return latesGitHubRelease.getTagName();
+    }
 
-        // example URL to get the content of a page: http://wiki.ivlab.ilabt.imec.be/rest/api/content/5407659?expand=body.storage
+    private static GitHubRelease getLatestGitHubRelease() throws RemoteVersionCheckFailedException {
 
-        String url = CoreConstants.EVS_WIKI_URL + CONFLUENCE_CONTENT_API_PATH + EVS_VERSION_WIKI_PAGE_ID + CONFLUENCE_CONTENT_API_QUERY_PARAMS;
-        String apiResonseString = null;
+        String url = GITHUB_API_BASE_URL + OWNER + "/" + REPO_NAME + LATEST_RELEASE_PATH;
+
         try {
-            apiResonseString = sendGetRequest(url);
+            String apiResponseString = sendGetRequest(url);
+            Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+            return gson.fromJson(apiResponseString, GitHubRelease.class);
         } catch (ExternalConnectionException e) {
             throw new RemoteVersionCheckFailedException(e);
         }
-
-        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
-        ApiResponse response = gson.fromJson(apiResonseString, ApiResponse.class);
-
-        if (response != null && response.getBody() != null && response.getBody().getStorage() != null) {
-            String body = response.getBody().getStorage().getValue();
-            return parseVersionFromPageBody(body);
-        }
-
-        throw new RemoteVersionCheckFailedException("No remote version returned: " + apiResonseString);
-
-    }
-
-    private static  String parseVersionFromPageBody(String pageBody) {
-
-        Pattern pattern = Pattern.compile("((?:\\d+\\.?){1,3})");
-
-        Matcher matcher = pattern.matcher(pageBody);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
-
-        return null;
 
     }
 
     private static String sendGetRequest(String url) throws ExternalConnectionException {
 
         try {
-
             RequestConfig.Builder requestBuilder = RequestConfig.custom().setConnectTimeout(CONNECTION_TIMEOUT).setSocketTimeout(SOCKET_TIMEOUT);
-
             HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
             httpClientBuilder.setDefaultRequestConfig(requestBuilder.build());
-
             CloseableHttpClient httpClient = httpClientBuilder.build();
-
             HttpGet request = new HttpGet(url);
-            request.addHeader("content-type", "application/json");
+            request.addHeader("Accept", "application/vnd.github.v3+json"); // Specify GitHub API version
             CloseableHttpResponse result = httpClient.execute(request);
             return EntityUtils.toString(result.getEntity(), "UTF-8");
-
         } catch (IOException e) {
             throw new ExternalConnectionException(e);
         }
 
     }
 
-    private class ApiResponse {
+    
+    // https://api.github.com/repos/smals-jy/evs/releases/latest
+    private static class GitHubRelease {
+        private String tag_name;
 
-        private Body Body;
-
-        public RemoteVersionReader.Body getBody() {
-            return Body;
-        }
-    }
-
-    private class Body {
-
-        private Storage storage;
-
-        public Storage getStorage() {
-            return storage;
-        }
-    }
-
-    private class Storage {
-
-        //private String representation;
-        private String value;
-
-        public String getValue() {
-            return value;
+        public String getTagName() {
+            return tag_name;
         }
 
     }
-
-
-
 }

--- a/core/src/test/java/org/imec/ivlab/core/version/RemoveVersionReaderTest.java
+++ b/core/src/test/java/org/imec/ivlab/core/version/RemoveVersionReaderTest.java
@@ -4,9 +4,7 @@ import org.testng.annotations.Test;
 
 public class RemoveVersionReaderTest {
 
-    // Turned off as it fails now
-    // Connect to wiki.ivlab.ilabt.imec.be:80 [wiki.ivlab.ilabt.imec.be/193.191.148.162] failed
-    @Test(enabled = false)
+    @Test
     public void testGetRemoteVersion() throws Exception {
         String remoteVersion = RemoteVersionReader.getRemoteVersion();
         System.out.print(remoteVersion);


### PR DESCRIPTION
RemoteVersionReader was somehow broken & produces all the time this message : 

```bash
Connect to wiki.ivlab.ilabt.imec.be:80 [wiki.ivlab.ilabt.imec.be/193.191.148.162] failed
```

My new solution (based on Github Releases) is so a better alternative for the future.

It works on my computer : 
![image](https://github.com/smals-jy/evs/assets/9306961/95921514-6c52-4c3a-8346-00e00a8a6ad1)
