### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/core/src/main/java/org/imec/ivlab/core/kmehr/tables/TableDefinitionReader.java
+++ b/core/src/main/java/org/imec/ivlab/core/kmehr/tables/TableDefinitionReader.java
@@ -271,6 +271,10 @@ public class TableDefinitionReader {
                     String tempFileName = TABLE_NAME_MARKER + StringUtils.substringAfterLast(matchingJarEntry, fileSeparatorInJarFile);
                     log.trace("Adding matching jar entry: " + matchingJarEntry + ". Name to be used for temp file: " + tempFileName);
                     File resourceAsFile = IOUtils.getResourceAsFile(fileSeparatorInJarFile + matchingJarEntry, tempFileName);
+                    // Validate the resource file path to prevent directory traversal
+                    if (!resourceAsFile.toPath().normalize().startsWith(new File(folderToScan).toPath().normalize())) {
+                        throw new IOException("Invalid resource file path: " + resourceAsFile.getAbsolutePath());
+                    }
                     log.trace("resource as file: " + resourceAsFile.getAbsolutePath());
                     files.add(resourceAsFile);
 

--- a/core/src/main/java/org/imec/ivlab/core/util/ResourceResolver.java
+++ b/core/src/main/java/org/imec/ivlab/core/util/ResourceResolver.java
@@ -88,9 +88,15 @@ public class ResourceResolver {
                 while (entries.hasMoreElements()) {
                     JarEntry jarEntry = entries.nextElement();
                     log.trace("Checking if: " + jarEntry.getName() + " starts with " + startsWith);
-                    if (org.apache.commons.lang3.StringUtils.startsWithIgnoreCase(jarEntry.getName(), startsWith)) {
-                        jarEntries.add(jarEntry.getName());
-                        log.trace("Found jar entry: " + jarEntry.getName());
+                    String entryName = jarEntry.getName();
+                    if (org.apache.commons.lang3.StringUtils.startsWithIgnoreCase(entryName, startsWith)) {
+                        // Validate the entry name to prevent directory traversal
+                        File entryFile = new File(entryName);
+                        if (!entryFile.toPath().normalize().startsWith(new File(startsWith).toPath().normalize())) {
+                            throw new IOException("Invalid jar entry: " + entryName);
+                        }
+                        jarEntries.add(entryName);
+                        log.trace("Found jar entry: " + entryName);
                     }
                 }
             }


### PR DESCRIPTION
Fixes [https://github.com/smals-jy/evs/security/code-scanning/1](https://github.com/smals-jy/evs/security/code-scanning/1)

To fix the problem, we need to ensure that the file paths constructed from jar entry names are validated to prevent directory traversal attacks. This can be achieved by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory. We will use `java.nio.file.Path.normalize()` and `java.nio.file.Path.startsWith()` for this purpose.

1. Modify the `getMatchingJarEntries` method in `ResourceResolver.java` to validate the jar entry names.
2. Ensure that the constructed file paths are within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
