### PR TITLE
feat: allow suspensions with wrong ID

### DIFF
--- a/core/src/main/java/org/imec/ivlab/core/kmehr/KmehrHelper.java
+++ b/core/src/main/java/org/imec/ivlab/core/kmehr/KmehrHelper.java
@@ -180,7 +180,8 @@ public class KmehrHelper {
 
         if (linkedSuspensionsCount < suspensionTransactions.size()) {
             // As this issue is possible in production environnements, EVS should not prevent this (to help integrators to reproduce this situation in acceptance) - only warn
-            LOG.warn("Some treatment suspension transactions don't link correctly to a medication scheme element transaction and can therefore not be linked. Please review the kmehr content");
+            int diffCount = suspensionTransactions.size() - linkedSuspensionsCount;
+            LOG.warn("{} treatment suspension transactions don't link correctly to a medication scheme element transaction and can therefore not be linked. Please review the kmehr content", diffCount);
         }
 
         return medicationAndLinkedSuspensions;

--- a/core/src/main/java/org/imec/ivlab/core/kmehr/KmehrHelper.java
+++ b/core/src/main/java/org/imec/ivlab/core/kmehr/KmehrHelper.java
@@ -179,7 +179,8 @@ public class KmehrHelper {
         }
 
         if (linkedSuspensionsCount < suspensionTransactions.size()) {
-            throw new RuntimeException("Some treatment suspension transactions don't link correctly to a medication scheme element transaction and can therefore not be linked. Please review the kmehr content");
+            // As this issue is possible in production environnements, EVS should not prevent this (to help integrators to reproduce this situation in acceptance) - only warn
+            LOG.warn("Some treatment suspension transactions don't link correctly to a medication scheme element transaction and can therefore not be linked. Please review the kmehr content");
         }
 
         return medicationAndLinkedSuspensions;


### PR DESCRIPTION
As this situation in production does occur & that nothing prevents it in fact, despite what said the cookbook https://www.ehealth.fgov.be/standards/kmehr/file/cc73d96153bbd5448a56f19d925d05b1379c7f21/057e64396c1ea312a0b01607b0f94e4adcf456e8/20210331-safe_cookbook_medicatieschema_v5.8_en.pdf

```
Link [1-1][:<link> (using a link to the transaction of the medicine will be defined)
ex: <lnk URL=”//transaction[id[@S=’ID-KMEHR’]=’5’]” TYPE=”isplannedfor”/>
Where 5 is the ID-KMEHR of the medicine to be suspended
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for medication and suspension transactions by logging warnings instead of stopping execution when some suspensions are not linked correctly. This ensures the process continues while still alerting users to potential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->